### PR TITLE
Fix FileNotFoundException when read config properties in jar file.

### DIFF
--- a/src/main/java/com/alipay/sofa/common/log/ReportUtil.java
+++ b/src/main/java/com/alipay/sofa/common/log/ReportUtil.java
@@ -24,8 +24,6 @@ package com.alipay.sofa.common.log;
  * Created by yangguanchao on 18/06/04.
  */
 @Deprecated
-public class ReportUtil extends com.alipay.sofa.common.utils.ReportUtil{
+public class ReportUtil extends com.alipay.sofa.common.utils.ReportUtil {
 
 }
-
-

--- a/src/test/java/com/alipay/sofa/common/log/factory/LoggerSpaceOverrideUsageTest.java
+++ b/src/test/java/com/alipay/sofa/common/log/factory/LoggerSpaceOverrideUsageTest.java
@@ -36,21 +36,29 @@ public class LoggerSpaceOverrideUsageTest {
             new SpaceInfo());
         ClassLoader classLoader = LoggerSpaceOverrideUsageTest.class.getClassLoader();
 
-        Assert.assertNull(builder.getResource(classLoader, null));
+        Assert.assertNull(builder.getResource(classLoader, null, null));
 
         List<URL> configFileUrls = new ArrayList<URL>();
-        Assert.assertNull(builder.getResource(classLoader, configFileUrls));
+
+        List<URL> propertyFileUrls = new ArrayList<URL>();
+        Assert.assertNull(builder.getResource(classLoader, configFileUrls, null));
 
         URL url1 = classLoader.getResource("com/alipay/sofa/testover1/log/log4j/log-conf.xml");
         configFileUrls.add(url1);
-        Assert.assertEquals(url1, builder.getResource(classLoader, configFileUrls));
+        Assert.assertEquals(url1, builder.getResource(classLoader, configFileUrls, null));
 
         URL url2 = classLoader.getResource("com/alipay/sofa/testover2/log/log4j/log-conf.xml");
+        URL p2 = classLoader.getResource("com/alipay/sofa/testover2/log/log4j/config.properties");
         configFileUrls.add(url2);
-        Assert.assertEquals(url2, builder.getResource(classLoader, configFileUrls));
+        propertyFileUrls.add(p2);
+        Assert.assertEquals(url2,
+            builder.getResource(classLoader, configFileUrls, propertyFileUrls));
 
         URL url3 = classLoader.getResource("com/alipay/sofa/testover3/log/log4j/log-conf.xml");
+        URL p3 = classLoader.getResource("com/alipay/sofa/testover3/log/log4j/config.properties");
         configFileUrls.add(url3);
-        Assert.assertEquals(url2, builder.getResource(classLoader, configFileUrls));
+        propertyFileUrls.add(p3);
+        Assert.assertEquals(url2,
+            builder.getResource(classLoader, configFileUrls, propertyFileUrls));
     }
 }

--- a/src/test/java/com/alipay/sofa/common/utils/AssertUtilTest.java
+++ b/src/test/java/com/alipay/sofa/common/utils/AssertUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.common.utils;
 
 import org.junit.Test;
@@ -10,7 +26,6 @@ import org.junit.Test;
  * @since 18/06/04
  */
 public class AssertUtilTest {
-
 
     /**
      * Method: isTrue(boolean expression, String message)
@@ -37,4 +52,4 @@ public class AssertUtilTest {
         AssertUtil.isNull(object, "null");
         AssertUtil.isNull(object);
     }
-} 
+}

--- a/src/test/java/com/alipay/sofa/common/utils/ReportUtilTest.java
+++ b/src/test/java/com/alipay/sofa/common/utils/ReportUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.common.utils;
 
 import com.alipay.sofa.common.log.ReportUtil;
@@ -25,4 +41,4 @@ public class ReportUtilTest {
         }
         assertFalse(isException);
     }
-} 
+}


### PR DESCRIPTION
### Motivation:

fix file read in jar

File exist. but we can not read 
```
java.io.FileNotFoundException: file:/xxx/custom-1.0.0.jar!/com/alipay/remoting/log/log4j/config.properties (没有那个文件或目录)
```

### Modification:

I compare parent path of files ,ensure get correct config.properties.

### Result:

